### PR TITLE
HOTFIX: Cookie age

### DIFF
--- a/public/js/common.js
+++ b/public/js/common.js
@@ -210,6 +210,9 @@ setTimeout(function () {
 }, CONSENT_TIMEOUT);
 
 ACCEPT_BUTTON.addEventListener("click", function () {
-    document.cookie = "yabe=yabe-online-mall; max-age=60*60*24*30; path=/; SameSite=None; Secure";  // cookie exists for 30 days
+    let date = new Date();  // Get current time
+    date.setTime(date.getTime() + 1000*60*60*24*30);  // Set time to 30 days from current time
+    console.log(date.toUTCString());
+    document.cookie = `yabe=yabe-online-mall; expires=${date.toUTCString()}; path=/; samesite=none; secure`;  // cookie exists for 30 days
     COOKIE_CONSENT.classList.remove("active");
 });

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -212,7 +212,6 @@ setTimeout(function () {
 ACCEPT_BUTTON.addEventListener("click", function () {
     let date = new Date();  // Get current time
     date.setTime(date.getTime() + 1000*60*60*24*30);  // Set time to 30 days from current time
-    console.log(date.toUTCString());
     document.cookie = `yabe=yabe-online-mall; expires=${date.toUTCString()}; path=/; samesite=none; secure`;  // cookie exists for 30 days
     COOKIE_CONSENT.classList.remove("active");
 });


### PR DESCRIPTION
**Bug:** Cookie age wasn't actually set to 30 days but only 1 minute after creation.
---
**Solution**
Re-implemented the cookie using the `Date` object and `;expires=` to make it actually set the cookie expiry to 30 days after creation.

```javascript
ACCEPT_BUTTON.addEventListener("click", function () {
    let date = new Date();  // Get current time
    date.setTime(date.getTime() + 1000*60*60*24*30);  // Set time to 30 days from current time
    document.cookie = `yabe=yabe-online-mall; expires=${date.toUTCString()}; path=/; samesite=none; secure`;  // cookie exists for 30 days
    COOKIE_CONSENT.classList.remove("active");
});
```