### PR TITLE
HOTFIX: GitHub pages 405 error

### DIFF
--- a/public/mall/account/login/index.html
+++ b/public/mall/account/login/index.html
@@ -81,7 +81,7 @@
 </header>
 
 <main class="dialog-container">
-  <form id="login-form" action="../my-account" method="post" autocomplete="on">
+  <form id="login-form" action="../my-account" autocomplete="on">
     <h1>READY? GO</h1>
     <label><input type="text" name="username" placeholder="Phone / Email" required></label>
     <label><input class="password-field" type="password" name="password" placeholder="Password" required></label>


### PR DESCRIPTION
**Bug:** Pressing on the "Login" button in [Login Page](https://kuri-team.github.io/yabe-online-mall/public/mall/account/login/) sends the user to a 405 error page. This is due to GitHub Pages deployment environment not supporting the POST method.
---
**Solution**
Removed `method=post` for login form.